### PR TITLE
Fix a bug - selecting wrong interface for live capture

### DIFF
--- a/BruteShark/PcapProcessor/Sniffer.cs
+++ b/BruteShark/PcapProcessor/Sniffer.cs
@@ -64,7 +64,9 @@ namespace PcapProcessor
             if (selectedDevice is SharpPcap.LibPcap.LibPcapLiveDevice)
             {
                 var livePcapDevice = selectedDevice as SharpPcap.LibPcap.LibPcapLiveDevice;
-                livePcapDevice.Open(PromisciousMode ? SharpPcap.DeviceModes.Promiscuous : SharpPcap.DeviceModes.None);
+                livePcapDevice.Open(mode: PromisciousMode ? SharpPcap.DeviceModes.Promiscuous : SharpPcap.DeviceModes.None 
+                                          | DeviceModes.DataTransferUdp 
+                                          | DeviceModes.NoCaptureLocal);
             }
             else
             {
@@ -98,7 +100,7 @@ namespace PcapProcessor
             // Raise events for unfinished sessions.
             HandleUnfinishedSessions();
         }
-
+     
         private void SetupBpfFilter(ICaptureDevice selectedDevice)
         {
             if (this.Filter != null && this.Filter != string.Empty)
@@ -136,14 +138,10 @@ namespace PcapProcessor
 
         private SharpPcap.ICaptureDevice GetSelectedDevice()
         {
-            var availiableDevices = CaptureDeviceList.Instance;
-
-            if (!AvailiableDevicesNames.Contains(this.SelectedDeviceName))
-            {
-                throw new Exception($"No such device {SelectedDeviceName}");
-            }
-
-            return availiableDevices[AvailiableDevicesNames.IndexOf(this.SelectedDeviceName)];
+            return CaptureDeviceList.Instance
+                .Select(d => (PcapDevice)d)
+                .Where(d => d.Interface.FriendlyName == this.SelectedDeviceName)
+                .FirstOrDefault();
         }
 
         private void StartPacketProcessingThread()


### PR DESCRIPTION
# Description
This PR fixed #99, a bug at the live capture option .
The bug caused that although a certain network interface was selected at the user interface, another network card was selected behind the scenes.
At first I thought it was a problem with capturing wireless network interfaces only, but in fact the phenomenon could happen with any network interface.
This PR also closes chmorgan/sharppcap#301, an issue opened for consulting with the kind SharpPcap developers.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
With latest versions of:
* SharpPcap 6.0.0
* Npcap 1.50