### PR TITLE
Add more fields to node data

### DIFF
--- a/BruteShark/BruteSharkCli/BruteSharkCli.cs
+++ b/BruteShark/BruteSharkCli/BruteSharkCli.cs
@@ -62,6 +62,10 @@ namespace BruteSharkCli
         {
             if (_args.Length == 0)
             {
+                Console.WriteLine("No arguments detected, type --help for usage.");
+            }
+            else if (_args[0] == "--debug")
+            {
                 RunShellMode();
             }
             else

--- a/BruteShark/BruteSharkCli/Cli Shell/CliShell.cs
+++ b/BruteShark/BruteSharkCli/Cli Shell/CliShell.cs
@@ -76,10 +76,10 @@ namespace BruteSharkCli
             AddCommand(new CliShellCommand("show-modules", p => PrintModules(), "Print modules."));
             AddCommand(new CliShellCommand("show-hashes", p => PrintHashes(), "Print Hashes"));
             AddCommand(new CliShellCommand("show-networkmap", p => PrintNetworkMap(), "Prints the network map as a json string. Usage: show-networkmap"));
-            AddCommand(new CliShellCommand("export-hashes", p => Utilities.ExportHashes(p, _hashes), "Export all Hashes to Hascat format input files. Usage: export-hashes <OUTPUT-DIRECTORY>"));
+            AddCommand(new CliShellCommand("export-hashes", p => Utilities.ExportHashes(p, _hashes), "Export all Hashes to Hashcat format input files. Usage: export-hashes <OUTPUT-DIRECTORY>"));
             AddCommand(new CliShellCommand("capture-from-device", p => InitLiveCapture(p), "Capture live traffic from a network device, Usage: capture-from-device <device-name>"));
-            AddCommand(new CliShellCommand("capture-promiscious-mode", p => sniffer.PromisciousMode = true, "Capture live traffic from a network device on promiscious mode (requires superuser privileges, default is normal mode)"));
-            AddCommand(new CliShellCommand("set-captrue-filter", p => VerifyFilter(p), "Set a capture filter to the live traffic capture(filters must be bpf syntax filters)"));
+            AddCommand(new CliShellCommand("capture-promiscuous-mode", p => sniffer.PromisciousMode = true, "Capture live traffic from a network device on promiscuous mode (requires superuser privileges, default is normal mode)"));
+            AddCommand(new CliShellCommand("set-capture-filter", p => VerifyFilter(p), "Set a capture filter to the live traffic capture(filters must be bpf syntax filters)"));
             AddCommand(new CliShellCommand("show-network-devices", p => PrintNetworkDevices(), "Show the available network devices for live capture"));
             AddCommand(new CliShellCommand("export-networkmap", p => CommonUi.Exporting.ExportNetworkMap(p, _connections), "Export network map to a json file for neo4j. Usage: export-networkmap <OUTPUT-file>"));
             AddCommand(new CliShellCommand("export-voip-calls", p => CommonUi.Exporting.ExportVoipCalls(p, _voipCalls), "Export the VoIP calls media to files. Usage: export-networkmap <OUTPUT-DIR>"));
@@ -239,7 +239,7 @@ namespace BruteSharkCli
                 try
                 {
                     Console.WriteLine(_sniffer.PromisciousMode ? 
-                        $"[+] Started analyzing packets from {_sniffer.SelectedDeviceName} device (Promiscious mode) - Press Ctrl + C to stop" : 
+                        $"[+] Started analyzing packets from {_sniffer.SelectedDeviceName} device (Promiscuous mode) - Press Ctrl + C to stop" : 
                         $"[+] Started analyzing packets from {_sniffer.SelectedDeviceName} device- Press Ctrl + C to stop");
 
                     _sniffer.StartSniffing(new System.Threading.CancellationToken());

--- a/BruteShark/BruteSharkCli/Properties/launchSettings.json
+++ b/BruteShark/BruteSharkCli/Properties/launchSettings.json
@@ -2,7 +2,11 @@
   "profiles": {
     "BruteSharkCli": {
       "commandName": "Project",
-      "commandLineArgs": "-d C:\\\\Users\\King\\\\github\\BS_NETWORK\\BruteShark\\Pcap_Examples -m Credentials,NetworkMap,FileExtracting,DNS -o C:\\\\Users\\King\\Desktop\\Test"
+      "commandLineArgs": " -l Wi-Fi -m Credentials,NetworkMap,FileExtracting,DNS -o C:\\Users\\King\\Desktop\\Test Export"
+    },
+    "No Parameters": {
+      "commandName": "Project",
+      "commandLineArgs": "--help"
     }
   }
 }

--- a/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandFlags.cs
+++ b/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandFlags.cs
@@ -7,29 +7,25 @@ namespace BruteSharkCli
 {
     public class SingleCommandFlags
     {
-        [Option('d', "input-dir", Required = false, SetName ="dir_input",  HelpText = "The input directory containing the files to be processed.")]
+        [Option('d', "input-dir", Required=false, SetName="dir_input",  HelpText="The input directory containing the files to be processed.")]
         public string InputDir { get; set; }
 
-        [Option('i', "input", Required = false, SetName = "files_input", Separator = ',', HelpText = "The files to be processed seperated by comma")]
+        [Option('i', "input", Required=false, SetName="files_input", Separator=',', HelpText ="The files to be processed separated by comma.")]
         public IEnumerable<string> InputFiles { get; set; }
 
-        [Option('m', "modules", Required = false , Separator = ',', HelpText = "The modules to be separterd by comma: Credentials, FileExtracting, NetworkMap, DNS, Voip")]
+        [Option('m', "modules", Required=false, Separator=',', HelpText="The modules to be separated by comma: Credentials, FileExtracting, NetworkMap, DNS, Voip.")]
         public IEnumerable<string> Modules { get; set; }
 
-        // TODO - merge parallel processing feature branch to make this flag really work
-        // [Option('p', "parallel", Required = false, HelpText = "Whether to process the files in parallel, default value is false.")]
-        // public bool ParallelProcessing { get; set; }
-
-        [Option('o', "output", Required = false, HelpText = "Output direcorty for the results files.")]
+        [Option('o', "output", Required=false, HelpText="Output directory for the results files.")]
         public string OutputDir { get; set; }
 
-        [Option('p', "promiscious", Required = false, HelpText = "Configures whether to start live capture on normal or promiscious mode (sometimes needs super user privileges to to do so),use along with -l for live catpure.")]
+        [Option('p', "promiscuous", Required=false, HelpText="Configures whether to start live capture with promiscuous mode (sometimes needs super user privileges to do so),use along with -l for live capture.")]
         public bool PromisciousMode { get; set; }
 
-        [Option('l', "live-capture", Required = false, Default = null, HelpText = "Caputre and process packets live from a network interface.")]
+        [Option('l', "live-capture", Required=false, Default=null, HelpText="Capture and process packets live from a network interface.")]
         public string CaptureDevice { get; set; }
         
-        [Option('f', "filter", Required = false, Default = null, HelpText = "add a capture bpf filter to the live traffic processing.")]
+        [Option('f', "filter", Required=false, Default=null, HelpText="Set a capture BPF filter to the live traffic processing.")]
         public string CaptrueFilter { get; set; }
     }
 }

--- a/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
+++ b/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
@@ -50,6 +50,8 @@ namespace BruteSharkCli
             _analyzer.ParsedItemDetected += OnParsedItemDetected;
             _analyzer.UpdatedItemProprertyDetected += UpdatedPropertyInItemDetected;
 
+            _processor.UdpSessionArrived += (s, e) => OnSessionArrived(e.UdpSession as PcapProcessor.INetworkSession<NetworkPacket>);
+            _processor.TcpSessionArrived += (s, e) => OnSessionArrived(e.TcpSession as PcapProcessor.INetworkSession<NetworkPacket>);
             _processor.ProcessingFinished += (s, e) => this.ExportResults();
             _processor.FileProcessingStatusChanged += (s, e) => this.PrintFileStatusUpdate(s, e);
 
@@ -58,6 +60,11 @@ namespace BruteSharkCli
 
             // Parse user arguments.
             CommandLine.Parser.Default.ParseArguments<SingleCommandFlags>(args).WithParsed<SingleCommandFlags>((cliFlags) => _cliFlags = cliFlags);
+        }
+
+        private void OnSessionArrived(PcapProcessor.INetworkSession<NetworkPacket> session)
+        {
+            _networkContext.NetworkSessions.Add(session);
         }
 
         public void Run()

--- a/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
+++ b/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
@@ -19,7 +19,6 @@ namespace BruteSharkCli
         private HashSet<PcapAnalyzer.NetworkFile> _extractedFiles;
         private HashSet<PcapAnalyzer.NetworkPassword> _passwords;
         private HashSet<CommonUi.VoipCall> _voipCalls;
-        private HashSet<PcapAnalyzer.DnsNameMapping> _dnsMappings;
 
         private Sniffer _sniffer; 
         private PcapProcessor.Processor _processor;
@@ -44,8 +43,6 @@ namespace BruteSharkCli
             _passwords = new HashSet<NetworkPassword>();
             _extractedFiles = new HashSet<NetworkFile>();
             _voipCalls = new HashSet<CommonUi.VoipCall>();
-            _dnsMappings = new HashSet<PcapAnalyzer.DnsNameMapping>();
-
 
             _analyzer.ParsedItemDetected += OnParsedItemDetected;
             _analyzer.UpdatedItemProprertyDetected += UpdatedPropertyInItemDetected;
@@ -78,7 +75,7 @@ namespace BruteSharkCli
                     SetupSniffer();
 
                     CliPrinter.Info(_sniffer.PromisciousMode ?
-                        $"Started analyzing packets from {_cliFlags.CaptureDevice} device (Promiscious mode) - Press Ctrl + C to stop" :
+                        $"Started analyzing packets from {_cliFlags.CaptureDevice} device (Promiscuous mode) - Press Ctrl + C to stop" :
                         $"Started analyzing packets from {_cliFlags.CaptureDevice} device - Press Ctrl + C to stop");
                     
                     _sniffer.StartSniffing(new System.Threading.CancellationToken());
@@ -140,7 +137,7 @@ namespace BruteSharkCli
 
         private void SetupRun()
         {
-            // That can happen when the user enter vesion \ help commad, exit gracefully.
+            // That can happen when the user enter version \ help command, exit gracefully.
             if (_cliFlags is null)
             {
                 Environment.Exit(0);
@@ -153,7 +150,7 @@ namespace BruteSharkCli
             }
             else
             {
-                throw new Exception("No mudules selected");
+                throw new Exception("No modules selected");
             }
 
             if (_cliFlags.InputFiles.Count() != 0 && _cliFlags.InputDir != null)
@@ -236,9 +233,9 @@ namespace BruteSharkCli
                     var dirPath = CommonUi.Exporting.ExportFiles(_cliFlags.OutputDir, _extractedFiles);
                     CliPrinter.Info($"Successfully exported extracted files to: {dirPath}");
                 }
-                if (_dnsMappings.Any())
+                if (_networkContext.DnsMappings.Any())
                 {
-                    var dnsFilePath = CommonUi.Exporting.ExportDnsMappings(_cliFlags.OutputDir, _dnsMappings);
+                    var dnsFilePath = CommonUi.Exporting.ExportDnsMappings(_cliFlags.OutputDir, _networkContext.DnsMappings);
                     CliPrinter.Info($"Successfully exported DNS mappings to file: {dnsFilePath}");
                 }
 				if(_voipCalls.Any())

--- a/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
+++ b/BruteShark/BruteSharkCli/Single Command Runner/SingleCommandRunner.cs
@@ -18,8 +18,6 @@ namespace BruteSharkCli
         private CommonUi.NetworkContext _networkContext;
         private HashSet<PcapAnalyzer.NetworkFile> _extractedFiles;
         private HashSet<PcapAnalyzer.NetworkPassword> _passwords;
-        private HashSet<PcapAnalyzer.NetworkHash> _hashes;
-        //private HashSet<PcapAnalyzer.NetworkConnection> _connections;
         private HashSet<CommonUi.VoipCall> _voipCalls;
         private HashSet<PcapAnalyzer.DnsNameMapping> _dnsMappings;
 
@@ -43,7 +41,6 @@ namespace BruteSharkCli
             _files = new List<string>();
 
             _networkContext = new NetworkContext();
-            _hashes = new HashSet<PcapAnalyzer.NetworkHash>();
             _passwords = new HashSet<NetworkPassword>();
             _extractedFiles = new HashSet<NetworkFile>();
             _voipCalls = new HashSet<CommonUi.VoipCall>();
@@ -222,9 +219,9 @@ namespace BruteSharkCli
                     var nodesDataFilePath = CommonUi.Exporting.ExportNetworkNodesData(_cliFlags.OutputDir, _networkContext.GetAllNodes());
                     CliPrinter.Info($"Successfully exported network nodes data to json file: {nodesDataFilePath}");
                 }
-                if (_hashes.Any())
+                if (_networkContext.Hashes.Any())
                 {
-                    Utilities.ExportHashes(_cliFlags.OutputDir, _hashes);
+                    Utilities.ExportHashes(_cliFlags.OutputDir, _networkContext.Hashes);
                     CliPrinter.Info($"Successfully exported hashes");
                 }
                 if (_files.Any())
@@ -240,11 +237,11 @@ namespace BruteSharkCli
 				if(_voipCalls.Any())
                 {
                    var dirPath = CommonUi.Exporting.ExportVoipCalls(_cliFlags.OutputDir, _voipCalls);
-                    CliPrinter.Info($"Successfully exported voip calls extracted to: {dirPath}");
+                    CliPrinter.Info($"Successfully exported Voip calls extracted to: {dirPath}");
                 }
             }
 
-            CliPrinter.Info("Bruteshark finished processing");
+            CliPrinter.Info("BruteShark finished processing");
         }
 
         private void AddFile(string filePath)
@@ -292,7 +289,7 @@ namespace BruteSharkCli
             }
             else if (e.ParsedItem is PcapAnalyzer.NetworkHash)
             {
-                if (_hashes.Add(e.ParsedItem as PcapAnalyzer.NetworkHash))
+                if (_networkContext.Hashes.Add(e.ParsedItem as PcapAnalyzer.NetworkHash))
                 {
                     PrintDetectedItem(e.ParsedItem);
                 }
@@ -307,7 +304,7 @@ namespace BruteSharkCli
             else if (e.ParsedItem is PcapAnalyzer.NetworkConnection)
             {
                 var networkConnection = e.ParsedItem as NetworkConnection;
-                _networkContext.Connections.Add(networkConnection);
+                _networkContext.HandleNetworkConection(networkConnection);
             }
             else if (e.ParsedItem is PcapAnalyzer.VoipCall)
             {
@@ -318,7 +315,7 @@ namespace BruteSharkCli
 			}
             else if (e.ParsedItem is PcapAnalyzer.DnsNameMapping)
             {
-                if (_dnsMappings.Add(e.ParsedItem as DnsNameMapping))
+                if (_networkContext.HandleDnsNameMapping(e.ParsedItem as DnsNameMapping))
                 {
                     PrintDetectedItem(e.ParsedItem);
                 }

--- a/BruteShark/BruteSharkCli/Utilities.cs
+++ b/BruteShark/BruteSharkCli/Utilities.cs
@@ -69,7 +69,7 @@ namespace BruteSharkCli
 
         internal static void ExportHashes(string dirPath, HashSet<PcapAnalyzer.NetworkHash> hashes)
         {
-            string hashesPath = Path.Combine(dirPath, "Hasehs");
+            string hashesPath = Path.Combine(dirPath, "Hashes");
             Directory.CreateDirectory(hashesPath);
 
             // Run on each Hash Type we found.

--- a/BruteShark/BruteSharkDesktop/JsonTreeViewLoader.cs
+++ b/BruteShark/BruteSharkDesktop/JsonTreeViewLoader.cs
@@ -32,14 +32,21 @@ namespace BruteSharkDesktop
             }
         }
 
-        private static void AddNode(JToken token, TreeNode inTreeNode)
+        private static void AddNode(JToken token, TreeNode inTreeNode, bool flatSingleValues = true)
         {
             if (token == null)
                 return;
             if (token is JValue)
             {
-                var childNode = inTreeNode.Nodes[inTreeNode.Nodes.Add(new TreeNode(token.ToString()))];
-                childNode.Tag = token;
+                if (flatSingleValues)
+                {
+                    inTreeNode.Text += ": " + token.ToString();
+                }
+                else
+                {
+                    var childNode = inTreeNode.Nodes[inTreeNode.Nodes.Add(new TreeNode(token.ToString()))];
+                    childNode.Tag = token;
+                }
             }
             else if (token is JObject jObject)
             {

--- a/BruteShark/BruteSharkDesktop/MainForm.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.cs
@@ -149,12 +149,12 @@ tshark -F pcap -r <pcapng file> -w <pcap file>";
 
         private void SwitchToMainThreadContext(Action func)
         {
-            // Thread-Safe mechanizm:
-            // Check if we are currently runing in a different thread than the one that 
+            // Thread-Safe mechanism:
+            // Check if we are currently running in a different thread than the one that 
             // control was created on, if so we invoke a call to our function again, but because 
             // we used the invoke method again from our form the caller this time will be the 
             // the thread that created the form.
-            // For more detailes: 
+            // For more details: 
             // https://docs.microsoft.com/en-us/dotnet/framework/winforms/controls/how-to-make-thread-safe-calls-to-windows-forms-controls
             if (InvokeRequired)
             {

--- a/BruteShark/BruteSharkDesktop/MainForm.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.cs
@@ -108,6 +108,7 @@ namespace BruteSharkDesktop
         private void OnProcessingFinished(object sender, EventArgs e)
         {
             this.progressBar.Value = this.progressBar.Maximum;
+            this.ResumeLayout();
             HandleFailedFiles();
         }
 

--- a/BruteShark/BruteSharkDesktop/MainForm.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.cs
@@ -77,7 +77,7 @@ namespace BruteSharkDesktop
             _networkMapUserControl.Dock = DockStyle.Fill;
             _sessionsExplorerUserControl = new SessionsExplorerUserControl(_networkContext);
             _sessionsExplorerUserControl.Dock = DockStyle.Fill;
-            _hashesUserControl = new HashesUserControl();
+            _hashesUserControl = new HashesUserControl(_networkContext);
             _hashesUserControl.Dock = DockStyle.Fill;
             _passwordsUserControl = new GenericTableUserControl();
             _passwordsUserControl.Dock = DockStyle.Fill;

--- a/BruteShark/BruteSharkDesktop/UserControls/HashesControl/HashesUserControl.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/HashesControl/HashesUserControl.cs
@@ -14,13 +14,15 @@ namespace BruteSharkDesktop
 {
     public partial class HashesUserControl : UserControl
     {
+        private CommonUi.NetworkContext _networkContext;
         private GenericTableUserControl _hashesTableUserControl; 
 
         public int HashesCount => _hashesTableUserControl.ItemsCount;
 
-        public HashesUserControl()
+        public HashesUserControl(CommonUi.NetworkContext networkContext)
         {
             InitializeComponent();
+            _networkContext = networkContext;
 
             this._hashesTableUserControl = new GenericTableUserControl();
             _hashesTableUserControl.Dock = DockStyle.Fill;
@@ -30,10 +32,11 @@ namespace BruteSharkDesktop
             this.mainSplitContainer.Panel1.Controls.Add(_hashesTableUserControl);
         }
 
-        // TODO: use PL object
         public void AddHash(PcapAnalyzer.NetworkHash networkHash)
         {
+            // TODO: use network context hashes as the only data source
             _hashesTableUserControl.AddDataToTable(networkHash);
+            _networkContext.Hashes.Add(networkHash);
 
             if (!this.hashesComboBox.Items.Contains(networkHash.HashType))
             {

--- a/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
@@ -123,11 +123,10 @@ namespace BruteSharkDesktop
             {
                 var edgeText = $"{hash.HashType} Hash";
 
-                // We want to get domain only if it is a Kerberos or NTLM hash.
-                if (hash.HashType.ToLower().StartsWith("kerberos") || hash.HashType.ToLower().StartsWith("ntlm"))
+                // If it is a domain related hash (e.g Kerberos, NTLM)
+                if (hash is PcapAnalyzer.IDomainCredential)
                 {
-                    // Usually the hashes domain is named "Domain" or "Realm".
-                    var domain = GetPropertyValue(hash, new string[] { "Domain", "Realm" });
+                    var domain = (hash as IDomainCredential).GetDoamin();
                     userName = domain.Length > 0 ? @$"{domain}\{userName}" : userName;
                 }
 

--- a/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
@@ -68,7 +68,7 @@ namespace BruteSharkDesktop
         {
             this.SuspendLayout();
 
-            // We creaete an edge object and save it in a HashTable to avoid inserting
+            // We create an edge object and save it in a HashTable to avoid inserting
             // double edges.
             var newEdge = new NetworkMapEdge()
             {

--- a/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/NetworkMapControl/NetworkMapUserControl.cs
@@ -116,26 +116,23 @@ namespace BruteSharkDesktop
 
         public void HandleHash(PcapAnalyzer.NetworkHash hash)
         {
-            // Usually the hashes username is named "User" \ "Username".
-            var user = GetPropValue(hash, "User");
-            var username = GetPropValue(hash, "Username");
-            var displayUserName = user != null ? user : username;
+            // Usually the hashes username is named "User" or "Username".
+            var userName = GetPropertyValue(hash, new string[] { "User", "Username"});
 
-            if (displayUserName != null)
+            if (userName.Length > 0)
             {
-                var domain = GetPropValue(hash, "Domain");
-                if (domain != null)
-                {
-                    if (domain.ToString().Length > 0)
-                    {
-                        displayUserName = domain.ToString() + @"\" + displayUserName;
-                    }
-                }
-
                 var edgeText = $"{hash.HashType} Hash";
 
-                AddEdge(displayUserName.ToString(), hash.Destination, edgeText);
-                _graph.FindNode(displayUserName.ToString()).Attr.FillColor = Microsoft.Msagl.Drawing.Color.LightGreen;
+                // We want to get domain only if it is a Kerberos or NTLM hash.
+                if (hash.HashType.ToLower().StartsWith("kerberos") || hash.HashType.ToLower().StartsWith("ntlm"))
+                {
+                    // Usually the hashes domain is named "Domain" or "Realm".
+                    var domain = GetPropertyValue(hash, new string[] { "Domain", "Realm" });
+                    userName = domain.Length > 0 ? @$"{domain}\{userName}" : userName;
+                }
+
+                AddEdge(userName, hash.Destination, edgeText);
+                _graph.FindNode(userName).Attr.FillColor = Microsoft.Msagl.Drawing.Color.LightGreen;
             }
         }
 
@@ -171,9 +168,28 @@ namespace BruteSharkDesktop
             return IPAddress.TryParse(ip, out IPAddress ipAddress);
         }
 
-        private static object GetPropValue(object src, string propName)
+        private static object GetPropertyValue(object src, string propName)
         {
             return src.GetType().GetProperty(propName)?.GetValue(src, null);
+        }
+
+        private string GetPropertyValue(object src, IEnumerable<string> propertiesNames)
+        {
+            var res = string.Empty;
+
+            foreach (var name in propertiesNames)
+            {
+                var value = GetPropertyValue(src, name);
+                var stringValue = value == null ? string.Empty : value.ToString();
+
+                if (stringValue.Length > 0)
+                {
+                    res = stringValue;
+                    break;
+                }
+            }
+
+            return res;
         }
 
     }

--- a/BruteShark/CommonUi/NetworkContext.cs
+++ b/BruteShark/CommonUi/NetworkContext.cs
@@ -16,14 +16,14 @@ namespace CommonUi
         public Dictionary<string, HashSet<int>> OpenPorts { get; private set; }
         public HashSet<PcapAnalyzer.DnsNameMapping> DnsMappings { get; private set; }
         public HashSet<PcapAnalyzer.NetworkConnection> Connections { get; private set; }
-        public HashSet<PcapProcessor.NetworkObject> NetworkSessions { get; private set; }
+        public HashSet<PcapProcessor.NetworkSession> NetworkSessions { get; private set; }
 
         public NetworkContext()
         {
             OpenPorts = new Dictionary<string, HashSet<int>>();
             DnsMappings = new HashSet<PcapAnalyzer.DnsNameMapping>();
             Connections = new HashSet<PcapAnalyzer.NetworkConnection>();
-            NetworkSessions = new HashSet<PcapProcessor.NetworkObject>();
+            NetworkSessions = new HashSet<PcapProcessor.NetworkSession>();
         }
 
         public bool HandleDnsNameMapping(PcapAnalyzer.DnsNameMapping dnsNameMapping)
@@ -53,6 +53,17 @@ namespace CommonUi
 
         private NetworkNode GetNode(string ipAddress)
         {
+            var tcpSessionsCount = 0;
+            var udpSessionsCount = 0;
+
+            foreach (var session in this.NetworkSessions)
+            {
+                if (session.Protocol == "TCP")
+                    tcpSessionsCount++;
+                else
+                    udpSessionsCount++;
+            }
+
             return new NetworkNode()
             {
                 IpAddress = ipAddress,

--- a/BruteShark/CommonUi/NetworkNode.cs
+++ b/BruteShark/CommonUi/NetworkNode.cs
@@ -22,6 +22,7 @@ namespace CommonUi
 
         [JsonProperty("UDP Streams Count")]
         public int UdpStreamsCount { get; set; }
+       
 
         public override bool Equals(object obj)
         {

--- a/BruteShark/CommonUi/NetworkNode.cs
+++ b/BruteShark/CommonUi/NetworkNode.cs
@@ -26,7 +26,7 @@ namespace CommonUi
         [JsonProperty("Sent Data")]
         public int SentData { get; set; }
 
-        [JsonProperty("Receive Data")]
+        [JsonProperty("Received Data")]
         public int ReceiveData { get; set; }
 
 

--- a/BruteShark/CommonUi/NetworkNode.cs
+++ b/BruteShark/CommonUi/NetworkNode.cs
@@ -22,7 +22,13 @@ namespace CommonUi
 
         [JsonProperty("UDP Streams Count")]
         public int UdpStreamsCount { get; set; }
-       
+
+        [JsonProperty("Sent Data")]
+        public int SentData { get; set; }
+
+        [JsonProperty("Receive Data")]
+        public int ReceiveData { get; set; }
+
 
         public override bool Equals(object obj)
         {

--- a/BruteShark/CommonUi/NetworkNode.cs
+++ b/BruteShark/CommonUi/NetworkNode.cs
@@ -29,6 +29,11 @@ namespace CommonUi
         [JsonProperty("Received Data")]
         public int ReceiveData { get; set; }
 
+        [JsonProperty("Domains and Users")]
+        public HashSet<string> Domains { get; set; }
+
+        [JsonProperty("Domain Users")]
+        public HashSet<string> DomainUsers { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosAsRepHash.cs
+++ b/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosAsRepHash.cs
@@ -4,11 +4,16 @@ using System.Text;
 
 namespace PcapAnalyzer
 {
-    public class KerberosAsRepHash : NetworkHash
+    public class KerberosAsRepHash : NetworkHash, IDomainCredential
     {
         public string Realm { get; set; }
         public string Username { get; set; }
         public string ServiceName { get; set; }
         public int Etype { get; set; }
+
+        public string GetDoamin() => this.Realm;
+
+        public string GetUsername() => this.Username;
+
     }
 }

--- a/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosHash.cs
+++ b/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosHash.cs
@@ -4,9 +4,14 @@ using System.Text;
 
 namespace PcapAnalyzer
 {
-    public class KerberosHash : NetworkHash
+    public class KerberosHash : NetworkHash, IDomainCredential
     {
         public string User { get; set; }
         public string Domain { get; set; }
+
+        public string GetDoamin() => this.Domain;
+
+        public string GetUsername() => this.User;
+
     }
 }

--- a/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosTgsRepHash.cs
+++ b/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/KerberosTgsRepHash.cs
@@ -4,11 +4,16 @@ using System.Text;
 
 namespace PcapAnalyzer
 {
-    public class KerberosTgsRepHash : NetworkHash
+    public class KerberosTgsRepHash : NetworkHash, IDomainCredential
     {
         public string Realm { get; set; }
         public string Username { get; set; }
         public string ServiceName { get; set; }
         public int Etype { get; set; }
+
+        public string GetDoamin() => this.Realm;
+
+        public string GetUsername() => this.Username;
+
     }
 }

--- a/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/NtlmHash.cs
+++ b/BruteShark/PcapAnalyzer/Modules/PasswordsModule/Hashes/NtlmHash.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace PcapAnalyzer
 {
-    public class NtlmHash : NetworkHash
+    public class NtlmHash : NetworkHash, IDomainCredential
     {
         public string Challenge { get; set; }
         public string User { get; set; }
@@ -12,5 +12,9 @@ namespace PcapAnalyzer
         public string LmHash { get; set; }
         public string NtHash { get; set; }
         public string Workstation { get; set; }
+
+        public string GetDoamin() => this.Domain;
+
+        public string GetUsername() => this.User;
     }
 }

--- a/BruteShark/PcapAnalyzer/Modules/PasswordsModule/IDomainCredential.cs
+++ b/BruteShark/PcapAnalyzer/Modules/PasswordsModule/IDomainCredential.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PcapAnalyzer
+{
+    public interface IDomainCredential
+    {
+        public string GetDoamin();
+        public string GetUsername();
+    }
+}

--- a/BruteShark/PcapProcessor/Objects/NetworkPacket.cs
+++ b/BruteShark/PcapProcessor/Objects/NetworkPacket.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PcapProcessor
+{
+    public interface INetworkPacket
+    {
+        public string SourceIp { get; set; }
+        public string DestinationIp { get; set; }
+        public int SourcePort { get; set; }
+        public int DestinationPort { get; set; }
+        public byte[] Data { get; set; }
+        public DateTime SentTime { get; set; }
+    }
+
+    public class NetworkPacket : INetworkPacket
+    {
+        public string SourceIp { get; set; }
+        public string DestinationIp { get; set; }
+        public int SourcePort { get; set; }
+        public int DestinationPort { get; set; }
+        public byte[] Data { get; set; }
+        public DateTime SentTime { get; set; }
+    }
+}

--- a/BruteShark/PcapProcessor/Objects/NetworkPacket.cs
+++ b/BruteShark/PcapProcessor/Objects/NetworkPacket.cs
@@ -14,7 +14,7 @@ namespace PcapProcessor
         public DateTime SentTime { get; set; }
     }
 
-    public class NetworkPacket : INetworkPacket
+    public abstract class NetworkPacket : INetworkPacket
     {
         public string SourceIp { get; set; }
         public string DestinationIp { get; set; }

--- a/BruteShark/PcapProcessor/Objects/NetworkSession.cs
+++ b/BruteShark/PcapProcessor/Objects/NetworkSession.cs
@@ -1,15 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace PcapProcessor
 {
-    public class NetworkSession
+    public interface INetworkSession<out T> where T : INetworkPacket
     {
         public string SourceIp { get; set; }
         public string DestinationIp { get; set; }
         public int SourcePort { get; set; }
         public int DestinationPort { get; set; }
         public string Protocol { get; set; }
+        public int SentData { get; }
+        public int ReceivedData { get; }
     }
+
+    public abstract class NetworkSession<T> : INetworkSession<T> where T : NetworkPacket
+    {
+        public string SourceIp { get; set; }
+        public string DestinationIp { get; set; }
+        public int SourcePort { get; set; }
+        public int DestinationPort { get; set; }
+        public string Protocol { get; set; }
+        public abstract List<T> Packets { get; set; }
+        public int SentData => Packets.Where(p => p.SourceIp == SourceIp).Sum(p => p.Data.Length);
+        public int ReceivedData => Packets.Where(p => p.DestinationIp == SourceIp).Sum(p => p.Data.Length);
+    }
+
 }

--- a/BruteShark/PcapProcessor/Objects/NetworkSession.cs
+++ b/BruteShark/PcapProcessor/Objects/NetworkSession.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace PcapProcessor
 {
-    public class NetworkObject
+    public class NetworkSession
     {
         public string SourceIp { get; set; }
         public string DestinationIp { get; set; }

--- a/BruteShark/PcapProcessor/Objects/NetworkSession.cs
+++ b/BruteShark/PcapProcessor/Objects/NetworkSession.cs
@@ -5,6 +5,12 @@ using System.Text;
 
 namespace PcapProcessor
 {
+    // This is a generic interface with a covariant parameter T (using the "out" keyword).
+    // The covariant is necessary because we want to return a specific derived type later (e.g TcpPacket)
+    // but still to treat to INetworkSession as base, e.g. create a list of types INetworkSession
+    // and add to that list different derived types like TcpSessions and UdpSessions on the fly.
+    // Another example at: 
+    // https://stackoverflow.com/questions/13280108/collection-of-derived-classes-that-have-generic-base-class
     public interface INetworkSession<out T> where T : INetworkPacket
     {
         public string SourceIp { get; set; }

--- a/BruteShark/PcapProcessor/Objects/TcpPacket.cs
+++ b/BruteShark/PcapProcessor/Objects/TcpPacket.cs
@@ -1,11 +1,7 @@
 ﻿namespace PcapProcessor
 {
-    public class TcpPacket
+    public class TcpPacket : NetworkPacket
     {
-        public string SourceIp { get; set; }
-        public string DestinationIp { get; set; }
-        public int SourcePort { get; set; }
-        public int DestinationPort { get; set; }
-        public byte[] Data { get; set; }
+        // This class is a placeholder for future data (e.g. TCP flags..)
     }
 }

--- a/BruteShark/PcapProcessor/Objects/TcpSession.cs
+++ b/BruteShark/PcapProcessor/Objects/TcpSession.cs
@@ -4,10 +4,10 @@ using System.Linq;
 
 namespace PcapProcessor
 {
-    public class TcpSession : NetworkSession
+    public class TcpSession : NetworkSession<TcpPacket>
     {
         public byte[] Data { get; set; }
-        public List<TcpPacket> Packets { get; set; }
+        public override List<TcpPacket> Packets { get; set; }
 
         public TcpSession()
         {

--- a/BruteShark/PcapProcessor/Objects/TcpSession.cs
+++ b/BruteShark/PcapProcessor/Objects/TcpSession.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PcapProcessor
 {
-    public class TcpSession : NetworkObject
+    public class TcpSession : NetworkSession
     {
         public byte[] Data { get; set; }
         public List<TcpPacket> Packets { get; set; }
-
 
         public TcpSession()
         {

--- a/BruteShark/PcapProcessor/Objects/UdpPacket.cs
+++ b/BruteShark/PcapProcessor/Objects/UdpPacket.cs
@@ -4,13 +4,8 @@ using System.Text;
 
 namespace PcapProcessor
 {
-    // TODO: Think of creating better hierarchy for this class and TcpPacket (e.g TransporPacket class) 
-    public class UdpPacket
+    public class UdpPacket : NetworkPacket
     {
-        public string SourceIp { get; set; }
-        public string DestinationIp { get; set; }
-        public int SourcePort { get; set; }
-        public int DestinationPort { get; set; }
-        public byte[] Data { get; set; }
+        // This class is a placeholder for future data and logic.
     }
 }

--- a/BruteShark/PcapProcessor/Objects/UdpSession.cs
+++ b/BruteShark/PcapProcessor/Objects/UdpSession.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PcapProcessor
 {
-    public class UdpSession : NetworkObject
+    public class UdpSession : NetworkSession
     {
         public byte[] Data { get; set; }
         public List<UdpPacket> Packets { get; set; }

--- a/BruteShark/PcapProcessor/Objects/UdpSession.cs
+++ b/BruteShark/PcapProcessor/Objects/UdpSession.cs
@@ -5,10 +5,10 @@ using System.Linq;
 
 namespace PcapProcessor
 {
-    public class UdpSession : NetworkSession
+    public class UdpSession : NetworkSession<UdpPacket>
     {
         public byte[] Data { get; set; }
-        public List<UdpPacket> Packets { get; set; }
+        public override List<UdpPacket> Packets { get; set; }
 
         public UdpSession()
         {


### PR DESCRIPTION
# Description

This Pull-Request contains some additional fields added to network node object (closes #56):
1. Sent data - The amount of data (bytes) sent by the host.
2. Received data - The amount of data received (bytes) by the host.
3. Domains - the domains that the host is a member of.
4. Domain users - domain users that logged into the host. 

For achieving that, few refactors was needed:
- Implement a generic covariant base for sessions (`INetworkSession`, `INetworkPacket`)
- Implement `IDomainCredential`  for identifying domain related credentials. 

In this order I also made the the old "Shell Mode" CLI to be used for debug purposes only.
 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

