### PR TITLE
"underscore" as seperator for file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,8 @@ MigrationBackup/
 
 # Ignore Visual Studio launchSettings (e.g application arguments)
 **/Properties/launchSettings.json
+
+# Ignore exported files
+/BruteShark/BruteShark_Network_Map.json
+/BruteShark/BruteShark_Network_Nodes_Data.json
+/BruteShark/BruteShark_DNS_Mappings.json

--- a/BruteShark/CommonUi/Exporting.cs
+++ b/BruteShark/CommonUi/Exporting.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 
 namespace CommonUi
@@ -38,12 +36,12 @@ namespace CommonUi
 
         public static string ExportNetworkMap(string dirPath, HashSet<PcapAnalyzer.NetworkConnection> connections)
         {
-            return ExportToFile(dirPath, "BruteShark Network Map.json", connections);
+            return ExportToFile(dirPath, "BruteShark_Network_Map.json", connections);
         }
 
         public static string ExportNetworkNodesData(string dirPath, List<NetworkNode> networkNodes)
         {
-            return ExportToFile(dirPath, "BruteShark Network Nodes Data.json", networkNodes);
+            return ExportToFile(dirPath, "BruteShark_Network_Nodes_Data.json", networkNodes);
         }
 
         public static string ExportFiles(string dirPath, HashSet<PcapAnalyzer.NetworkFile> networkFiles)
@@ -79,7 +77,7 @@ namespace CommonUi
 
         public static string ExportDnsMappings(string dirPath, HashSet<PcapAnalyzer.DnsNameMapping> dnsMappings)
         {
-            var filePath = GetUniqueFilePath(Path.Combine(dirPath, "BruteShark DNS Mappings.json"));
+            var filePath = GetUniqueFilePath(Path.Combine(dirPath, "BruteShark_DNS_Mappings.json"));
 
             File.WriteAllLines(
                 filePath, 


### PR DESCRIPTION
# Description

Fixes issue #129 
Switched from spaces as file name seperator to "_" (underscore) and updated .gitignore to include the new file names.

## Type of change

_Put an `X` in the relevant boxes_

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please generally describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Did multiple exports and checked file names afterwards to verfiy.

**Test Configuration**:
* OS: Win 10
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have adequately commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings (if there are any, note them and why they could not have been removed)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
